### PR TITLE
Fix error when sending a gcm notification

### DIFF
--- a/app/models/notify_user/delivery.rb
+++ b/app/models/notify_user/delivery.rb
@@ -12,7 +12,11 @@ module NotifyUser
 
     def log_response_for_device(device_id, response)
       current_responses = responses || {}
-      self.update(responses: current_responses.merge({ device_id => { status: response.status, body: response.body } }))
+      if channel == 'gcm'
+        self.update(responses: current_responses.merge({ device_id => { status: response[:status_code], body: response[:body] } }))
+      else
+        self.update(responses: current_responses.merge({ device_id => { status: response.status, body: response.body } }))
+      end
     end
 
     private


### PR DESCRIPTION
The response is structured differently to a apns notification in a few
ways.
It is a hash.
.status is :status_code
.body is :body