### PR TITLE
Add error call back handler

### DIFF
--- a/app/models/notify_user/apn_connection.rb
+++ b/app/models/notify_user/apn_connection.rb
@@ -39,6 +39,8 @@ module NotifyUser
       end
 
       @connection = Apnotic::Connection.new(cert_path: certificate)
+      @connection.on(:error) { |exception| p "Exception has been raised: #{exception}" }
+      @connection
     end
 
     def development_certificate

--- a/app/workers/notify_user/delivery_worker.rb
+++ b/app/workers/notify_user/delivery_worker.rb
@@ -1,3 +1,5 @@
+require 'que'
+
 module NotifyUser
   class DeliveryWorker < Que::Job
     def run(delivery_id)

--- a/notify_user.gemspec
+++ b/notify_user.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency "active_model_serializers", "~> 0.10.0"
   s.add_dependency "pubnub"
   s.add_dependency "houston"
-  s.add_dependency "apnotic", "~> 1.0.1"
+  s.add_dependency "apnotic", "~> 1.3"
   s.add_dependency "connection_pool"
   s.add_dependency "gcm"
 


### PR DESCRIPTION
Occasionally apnotic/http2 will throw a socket error which will kill off
the main thread.  This means that que will have to be restarted which
may loose some jobs.  By using a callback handler this is caught and
logged and then retried by que