### PR TITLE
Skip to next supported platform

### DIFF
--- a/app/models/notify_user/scheduler.rb
+++ b/app/models/notify_user/scheduler.rb
@@ -13,7 +13,7 @@ module NotifyUser
         aggregator = Aggregator.new(notification, options[:aggregate_per])
         return if aggregator.has_pending_deliveries?
         # Only deliver if the target has the required device
-        return if notification.target.devices.none? do |device|
+        next if notification.target.devices.none? do |device|
           device.platform == options[:platform]
         end
 


### PR DESCRIPTION
If the user only supports android it will return from first iteration of
the loop which checks ios and will never send a delivery for android.  Using next
it should skip to the supporting platform.