### PR TITLE
Send notifications in background

### DIFF
--- a/app/models/notify_user/factories/apns.rb
+++ b/app/models/notify_user/factories/apns.rb
@@ -11,6 +11,7 @@ module NotifyUser
         buildable.badge = count_for_target(notification.target)
         buildable.category = notification.params[:category] || notification.type
         buildable.sound = options[:sound] || 'default'
+        buildable.content_available = true
         buildable.custom_payload = { "custom_data" => notification.sendable_params }
         buildable.topic = ENV['APN_TOPIC']
 


### PR DESCRIPTION
When we send notifications for apns we want the notifications to be received by the app even if its in the background.  With this ability it gives us a way to store sent offers which can be marked as read.